### PR TITLE
Fix #1

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -41,3 +41,34 @@ test('works', () => {
       expect(actual).toEqual([10, 20, 30, 40, 50])
     })
 })
+
+test('works with pullable sampler', () => {
+  const actual = []
+
+  const samplerPulls = []
+  const samplerSubject = subject()
+  const sampler = (start, sink) => {
+    if (start !== 0) return
+    sink(0, (t, d) => {
+      if (t === 1) samplerPulls.push(d)
+    })
+    samplerSubject(0, (t, d) => {
+      if (t === 1) sink(1, d)
+    })
+  }
+
+  pipe(
+    fromIter([10, 20, 30]),
+    pullWhen(sampler),
+  )(0, (t, d) => {
+    if (t === 1) actual.push(d)
+  })
+
+  expect(actual).toEqual([])
+  samplerSubject(1)
+  for (let i = 1; i <= 3; i++) {
+    expect(samplerPulls).toEqual([10 * i])
+    samplerSubject(1, samplerPulls.pop())
+  }
+  expect(actual).toEqual([10, 20, 30])
+})

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,20 @@ export default function pullWhen(sampler) {
 
     let pullableTalkback
     let samplerTalkback
+    let terminated = false
 
     pullable(0, (type, data) => {
       if (type === 0) {
         pullableTalkback = data
+
+        sink(0, end => {
+          if (end !== 2) return
+
+          terminated = true
+          pullableTalkback(2)
+          samplerTalkback(2)
+        })
+        if (terminated) return
 
         sampler(0, (type, data) => {
           if (type === 0) {
@@ -21,28 +31,23 @@ export default function pullWhen(sampler) {
           }
 
           if (type === 2) {
+            terminated = true
             pullableTalkback(2)
             sink(2)
             return
           }
-        })
-
-        sink(0, end => {
-          if (end !== 2) return
-
-          pullableTalkback(2)
-          samplerTalkback(2)
         })
         return
       }
 
       if (type === 1) {
         sink(1, data)
-        samplerTalkback(1, data)
+        if (!terminated) samplerTalkback(1, data)
         return
       }
 
       if (type === 2) {
+        terminated = true
         samplerTalkback(2)
         sink(2)
         return

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ export default function pullWhen(sampler) {
 
       if (type === 1) {
         sink(1, data)
+        samplerTalkback(1, data)
         return
       }
 


### PR DESCRIPTION
With this change, whenever the input source emit, the sampler is pulled right after passing the data to the sink.
This enables things like pulling the source one second after it emitted an item, by simply creating a pullable asyncronous sampler.

The test case simulates such a behavior.

The sampler adds pulls to a list `samplerPulls`, and subscribes to a separate `samplerSubject`.

Whenever the pipe emits a value, the test takes an item out of `samplerPulls` to check if the sampler was pulled correctly.

Then it passes the item to ´samplerSubject` to cause the sampler to emit that value, which will result in another pull to the source.